### PR TITLE
Allocate enough memory for matchptr

### DIFF
--- a/dict_voikko.c
+++ b/dict_voikko.c
@@ -134,7 +134,7 @@ Datum dvoikko_lexize(PG_FUNCTION_ARGS) {
 	int		*lex_n;
 	char		*base, *p, *match;
 	size_t		nmatch = 20;
-	regmatch_t	*matchptr = palloc0(nmatch * sizeof(matchptr));
+	regmatch_t	*matchptr = palloc0(nmatch * sizeof(regmatch_t));
 	regmatch_t	matchp;
 
 	if (*txt == '\0' || searchstoplist(&(d->stoplist), txt)) {


### PR DESCRIPTION
We need space for 20 `regmatch_t` structures (16 bytes each -> 320 bytes), not 20 pointers (8 bytes each -> 160 bytes). This causes memory corruption and server crash in the right circumstances....